### PR TITLE
put update on same line as install or update has no effect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM nvidia/cuda:12.1.1-devel-ubuntu22.04
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update
-RUN apt-get install -y python3 python3-pip gfortran build-essential libhdf5-openmpi-dev openmpi-bin pkg-config libopenmpi-dev openmpi-bin libblas-dev liblapack-dev libpnetcdf-dev git python-is-python3 wget
+RUN apt-get update && apt-get install -y python3 python3-pip gfortran build-essential libhdf5-openmpi-dev openmpi-bin pkg-config libopenmpi-dev openmpi-bin libblas-dev liblapack-dev libpnetcdf-dev git python-is-python3 wget
 RUN pip3 install numpy matplotlib h5py sympy scipy
 RUN wget https://julialang-s3.julialang.org/bin/linux/x64/1.6/julia-1.6.7-linux-x86_64.tar.gz
 RUN tar -zxvf julia-1.6.7-linux-x86_64.tar.gz


### PR DESCRIPTION
The Dockerfile defines the build environment, including all of the packages that are installed. Previously, there was a line that updated all of the package definitions, followed by another line that installs certain packages. It turns out that these need to be on the same line for the update line to actually do anything.